### PR TITLE
extend buildPhotoURL with all prefixes available

### DIFF
--- a/phpFlickr.php
+++ b/phpFlickr.php
@@ -361,12 +361,21 @@ if ( !class_exists('phpFlickr') ) {
 			//file size exists)
 			$sizes = array(
 				"square" => "_s",
+				"square_75" => "_s",
+				"square_150" => "_q",
 				"thumbnail" => "_t",
 				"small" => "_m",
+				"small_240" => "_m",
+				"small_320" => "_n",
 				"medium" => "",
+				"medium_500" => "",
 				"medium_640" => "_z",
+				"medium_800" => "_c",
 				"large" => "_b",
-				"original" => "_o"
+				"large_1024" => "_b",
+				"large_1600" => "_h",
+				"large_2048" => "_k",
+				"original" => "_o",
 			);
 
 			$size = strtolower($size);


### PR DESCRIPTION
I added all possibles sizes to buildPhotoURL method
reference: http://www.mousewheel.net/suffixes-image-sizes-flickr-and-facebook
