### PR TITLE
Correcting socket connection to use SSL

### DIFF
--- a/phpFlickr.php
+++ b/phpFlickr.php
@@ -227,7 +227,7 @@ if ( !class_exists('phpFlickr') ) {
 				}
 				$data = implode('&', $data);
 
-				$fp = @pfsockopen($matches[1], 80);
+				$fp = @pfsockopen('ssl://'.$matches[1], 443);
 				if (!$fp) {
 					die('Could not connect to the web service');
 				}


### PR DESCRIPTION
Using SSL on port 443 as required by changes from Flickr for people not using CURL library.
