### PR TITLE
Fixed example.php so that it works with the current Flickr API

### DIFF
--- a/example.php
+++ b/example.php
@@ -18,13 +18,15 @@ $f = new phpFlickr("<api key>");
 
 $recent = $f->photos_getRecent();
 
-foreach ($recent['photo'] as $photo) {
-    $owner = $f->people_getInfo($photo['owner']);
-    echo "<a href='http://www.flickr.com/photos/" . $photo['owner'] . "/" . $photo['id'] . "/'>";
-    echo $photo['title'];
-    echo "</a> Owner: ";
-    echo "<a href='http://www.flickr.com/people/" . $photo['owner'] . "/'>";
-    echo $owner['username'];
-    echo "</a><br>";
+foreach ($recent['photos'] as $photos) {
+    foreach ($photos as $photo) {
+        $owner = $f->people_getInfo($photo['owner']);
+        echo "<a href='http://www.flickr.com/photos/" . $photo['owner'] . "/" . $photo['id'] . "/'>";
+        echo $photo['title'];
+        echo "</a> Owner: ";
+        echo "<a href='http://www.flickr.com/people/" . $photo['owner'] . "/'>";
+        echo $owner['username']['_content'];
+        echo "</a><br>";
+    }
 }
 ?>


### PR DESCRIPTION
Probably Flickr's API resopnse has changed since the initial commit of this project.
Now the flickr.photos.getRecent gives result array one level deeper and photos
are placed inside a new "photos" level.

Also the flickr.people.getInfo output has changed and username is put inside a
new array having a key "_content".
