### PR TITLE
Updated async_upload, sync_upload and replace with CurlFile call to avoid warning

### DIFF
--- a/phpFlickr.php
+++ b/phpFlickr.php
@@ -427,7 +427,7 @@ if ( !class_exists('phpFlickr') ) {
 				}
 
 				$photo = realpath($photo);
-				$args['photo'] = new CurlFile($photo, 'image/png', $photo);
+				$args['photo'] = new CurlFile($photo, mime_content_type($photo), $photo);
 
 
 				$curl = curl_init($this->upload_endpoint);
@@ -489,7 +489,7 @@ if ( !class_exists('phpFlickr') ) {
 				}
 
 				$photo = realpath($photo);
-				$args['photo'] = new CurlFile($photo, 'image/png', $photo);
+				$args['photo'] = new CurlFile($photo, mime_content_type($photo), $photo);
 
 
 				$curl = curl_init($this->upload_endpoint);
@@ -550,7 +550,7 @@ if ( !class_exists('phpFlickr') ) {
 				}
 
 				$photo = realpath($photo);
-				$args['photo'] = new CurlFile($photo, 'image/png', $photo);
+				$args['photo'] = new CurlFile($photo, mime_content_type($photo), $photo);
 
 
 				$curl = curl_init($this->replace_endpoint);


### PR DESCRIPTION
I was getting a deprecation warning about using '@' when referencing a file when uploading, so I updated to use CurlFile() to stop this.
