### PR TITLE
Reverts a default behaviour that was changed in a previous commit.

### DIFF
--- a/phpFlickr.php
+++ b/phpFlickr.php
@@ -309,8 +309,8 @@ if ( !class_exists('phpFlickr') ) {
 			 * and you're concerned about time.  This will, however, change the structure of
 			 * the result, so be sure that you look at the results.
 			 */
-			$this->parsed_response = json_decode($this->response, TRUE);
-/* 			$this->parsed_response = $this->clean_text_nodes(json_decode($this->response, TRUE)); */
+			//$this->parsed_response = json_decode($this->response, true);
+ 			$this->parsed_response = $this->clean_text_nodes(json_decode($this->response, true));
 			if ($this->parsed_response['stat'] == 'fail') {
 				if ($this->die_on_error) die("The Flickr API returned the following error: #{$this->parsed_response['code']} - {$this->parsed_response['message']}");
 				else {


### PR DESCRIPTION
[This commit](https://github.com/dan-coulter/phpflickr/commit/fe6f493de1aabe0a34d50fa7bab489494716942f#diff-9b9a87a6f1636876e0a3987693811e9cR319) changed the default behaviour of the `request()` function to _not_ clean text nodes as they come in, resulting in drastic structural changes to almost all data coming back from Flickr.

This update reverts the code back to the original behaviour (but still with mikeMTOL's improvements) so it will not break any apps that have already been using phpFlickr and decide to update.

I guess the problem here is that (I think) this fix solves between three to five current issues logged with the repository (https://github.com/dan-coulter/phpflickr/issues/48, https://github.com/dan-coulter/phpflickr/issues/36, https://github.com/dan-coulter/phpflickr/issues/41, https://github.com/dan-coulter/phpflickr/issues/25, and https://github.com/dan-coulter/phpflickr/issues/23) but I understand that whilst this saves existing apps that have _updated_ their phpFlickr submodule, it will potentially break new apps that have been using phpFlickr since [this commit](https://github.com/dan-coulter/phpflickr/commit/fe6f493de1aabe0a34d50fa7bab489494716942f#diff-9b9a87a6f1636876e0a3987693811e9cR319) on the 26th of May.

I'll submit this pull request and leave comments on all issues I think are affected. I'll leave the choice to merge up to @dan-coulter.
